### PR TITLE
MSVC build shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required (VERSION 3.14.3)
 
+option(BUILD_SHARED_LIBS "" ON)
+
 set(Openslide_MAJOR_VERSION 3)
 set(Openslide_MINOR_VERSION 4)
 set(Openslide_PATCH_VERSION 1)
@@ -184,7 +186,10 @@ set_target_properties(${openslidelib} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(${openslidelib} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src> $<INSTALL_INTERFACE:${Openslide_INSTALL_INCLUDE_DIR}>)
 target_link_libraries(${openslidelib} PUBLIC ${linked_libs})
 #target_compile_definitions(${openslidelib} PRIVATE -DUSE_CMAKE_LIBS)
-#target_compile_definitions(${openslidelib} PRIVATE -D_OPENSLIDE_BUILDING_DLL)
+
+if(BUILD_SHARED_LIBS)
+  target_compile_definitions(${openslidelib} PRIVATE -D_OPENSLIDE_BUILDING_DLL)
+endif()
 
 set_target_properties(${openslidelib} PROPERTIES PUBLIC_HEADER "${headers}")
 set_target_properties(${openslidelib} PROPERTIES CXX_VISIBILITY_PRESET hidden)

--- a/src/openslide-decode-tifflike.c
+++ b/src/openslide-decode-tifflike.c
@@ -134,7 +134,7 @@ static void fix_byte_order(void *data, int32_t size, int64_t count,
 static uint64_t read_uint(FILE *f, int32_t size, bool big_endian, bool *ok) {
   g_assert(ok != NULL);
 #ifdef _MSC_VER
-  uint8_t buf = (uint8_t*)calloc(size, sizeof(uint8_t));
+  uint8_t* buf = (uint8_t*)calloc(size, sizeof(uint8_t));
 #else
   uint8_t buf[size];
 #endif
@@ -178,6 +178,7 @@ static uint64_t read_uint(FILE *f, int32_t size, bool big_endian, bool *ok) {
   }
   default:
     g_assert_not_reached();
+    return 0;
   }
 }
 
@@ -533,7 +534,7 @@ static struct tiff_directory *read_directory(FILE *f, int64_t *diroff,
 
     // read in the value/offset
 #ifdef _MSC_VER
-    uint8_t value = (uint8_t*)calloc(bigtiff ? 8 : 4, sizeof(uint8_t));
+    uint8_t* value = (uint8_t*)calloc(bigtiff ? 8 : 4, sizeof(uint8_t));
 #else    
     uint8_t value[bigtiff ? 8 : 4];
 #endif

--- a/src/openslide-features.h
+++ b/src/openslide-features.h
@@ -45,11 +45,11 @@
 
 // for exporting from shared libraries or DLLs
 #if defined _WIN32 || defined _WIN64
-//#  ifdef _OPENSLIDE_BUILDING_DLL
+#  ifdef _OPENSLIDE_BUILDING_DLL
 #    define OPENSLIDE_PUBLIC() __declspec(dllexport)
-//#  else
-//#    define OPENSLIDE_PUBLIC() __declspec(dllimport)
-//#  endif
+#  else
+#    define OPENSLIDE_PUBLIC() __declspec(dllimport)
+#  endif
 #elif defined OPENSLIDE_SIMPLIFY_HEADERS
 // avoid constructs that could confuse a simplistic header parser
 # define OPENSLIDE_PUBLIC()


### PR DESCRIPTION
These changes allow Openslide to be built and used on Windows with Visual Studio as a shared library (dll).

Tested with Visual Studio 2019, v16.7.5.